### PR TITLE
code cleanup CODBlackOps.asl

### DIFF
--- a/CODBlackOps.asl
+++ b/CODBlackOps.asl
@@ -1,96 +1,45 @@
-state("BlackOps")
-{
-	string70 map : 0x21033E8;
-	long loading1: 0x1656804;	
+state("BlackOps") {
+    string14 map : 0x21033E8;
+    long loading : 0x1656804;
 }
 
-startup 
-{
-	vars.missions = new Dictionary<string,string> { 
-	  {"vorkuta", "Vorkuta"},
-		{"pentagon", "USDD"},
-		{"flashpoint", "Executive Order"},
-		{"khe_sanh", "SOG"},
-		{"hue_city", "The Defector"},
-		{"kowloon", "Numbers"},
-		{"fullahead", "Project Nova"},
-		{"creek_1", "Victor Charlie"},
-		{"river", "Crash Site"},
-		{"wmd_sr71", "WMD"},
-		{"pow", "Payback"}, 
-		{"rebirth", "Rebirth"},
-		{"int_escape", "Revelations"},
-		{"underwaterbase", "Redemption"},
-		{"outro", "Menu Screen"},
-		}; 
-    foreach (var Tag in vars.missions) {
-    settings.Add(Tag.Key, true, Tag.Value);
+startup {
+    var missions = new Dictionary<string,string> {
+        {"vorkuta", "Vorkuta"},
+        {"pentagon", "USDD"},
+        {"flashpoint", "Executive Order"},
+        {"khe_sanh", "SOG"},
+        {"hue_city", "The Defector"},
+        {"kowloon", "Numbers"},
+        {"fullahead", "Project Nova"},
+        {"creek_1", "Victor Charlie"},
+        {"river", "Crash Site"},
+        {"wmd_sr71", "WMD"},
+        {"pow", "Payback"},
+        {"rebirth", "Rebirth"},
+        {"int_escape", "Revelations"},
+        {"underwaterbase", "Redemption"},
+        {"outro", "Menu Screen"}
     };
 
-    
-  	vars.onStart = (EventHandler)((s, e) => // thanks gelly for this, it's basically making sure it always clears the vars no matter how livesplit starts
-        {
-        vars.doneMaps.Clear();
-        });
+    foreach (var mission in missions)
+        settings.Add(mission.Key, true, mission.Value);
 
-    timer.OnStart += vars.onStart; 
-
-	if (timer.CurrentTimingMethod == TimingMethod.RealTime) // stolen from dude simulator 3, basically asks the runner to set their livesplit to game time
-        {        
-        var timingMessage = MessageBox.Show (
-               "This game uses Time without Loads (Game Time) as the main timing method.\n"+
-                "LiveSplit is currently set to show Real Time (RTA).\n"+
-                "Would you like to set the timing method to Game Time? This will make verification easier",
-                "LiveSplit | Call of Duty: Black Ops",
-               MessageBoxButtons.YesNo,MessageBoxIcon.Question
-            );
-        
-            if (timingMessage == DialogResult.Yes)
-            {
-                timer.CurrentTimingMethod = TimingMethod.GameTime;
-            }
-        }	
-
+    timer.CurrentTimingMethod = TimingMethod.GameTime;
 }
 
-init 
-{
-	vars.doneMaps = new List<string>(); 
+start {
+    return current.map == "cuba" && current.loading != 0 && old.loading == 0;
 }
 
-start
-{
-    if ((current.map == "cuba") && (current.loading1 != 0)) {
-        vars.doneMaps.Clear();
-        return true;
-    }
+split {
+    return current.map != old.map && settings[current.map];
 }
 
-isLoading
-{
-	return (current.loading1 == 0);
+reset {
+    return current.map == "frontend";
 }
 
-
-reset
-{
-	return (current.map == "frontend");
-}
-
-split
-{
-    if ((current.map != old.map) && (vars.doneMaps != old.maps))
-    {
-	    if (settings[current.map]) 
-      {
-	      vars.doneMaps.Add(old.map);
-				return true;
-			}
-    }			
-}
-
-
-exit 
-{
-    timer.OnStart -= vars.onStart;
+isLoading {
+    return current.loading == 0;
 }


### PR DESCRIPTION
Removed `vars.doneMaps` (and all functions pertaining to it), as a player is unable to go to a previous map in this game. Removed timing message (can be reenabled) and instead sets timing method to game time whenever the user loads the script.
Removed useless brackets, set `map` string length to 14 (since the longest map name in `missions` is "underwaterbase").