### PR TITLE
[The Evil Within 2] Fix loading, and make platform and version independent

### DIFF
--- a/TheEvilWithin2.asl
+++ b/TheEvilWithin2.asl
@@ -82,8 +82,8 @@ update
     // but I don't think this value changes so hardcoding it here
     current.x = vars.Helper.Read<float>(vars.playerPositionBaseScan, 0xBD0 + 0x0);
     current.y = vars.Helper.Read<float>(vars.playerPositionBaseScan, 0xBD0 + 0x4);
-    
     // z at 0x8
+    
     // I constructed this by stepping through the assembly and working my way up
     // this is *not* randomly scanned
     current.isPaused = vars.Helper.Read<bool>(vars.uiParentScan, 0x28, 0x0, 0x80, 0x1C8, 0x18, 0x8, 0x8, 0xC);

--- a/TheEvilWithin2.asl
+++ b/TheEvilWithin2.asl
@@ -177,7 +177,7 @@ split
 
 isLoading
 {
-    return current.spinnerType == 3    // spinner is loading_area (monitor / computer warps)
+    return current.spinnerTypeString == "loading_area" // during monitor warps
         || current.isPaused            // self-explanatory!
         // user is entering a load screen, since it is deleted when the level unloads
         // (which causes isPaused to be 0 due to ZeroOrNull)

--- a/TheEvilWithin2.asl
+++ b/TheEvilWithin2.asl
@@ -1,8 +1,5 @@
 state("TEW2", "Current Patch")
 {
-    float ComputerLoad : 0x2ABFC1D; // 2 while loading
-    int Pause : 0x3734978; // just for rn to see what the mod wants
-    int Loading : 0x246624E; // loading 0 
     int Chapter : 0x03712248, 0x5C;
     float x : 0x39CA190;
     float y : 0x39CA194; 
@@ -11,9 +8,6 @@ state("TEW2", "Current Patch")
 
 state("TEW2", "1.02")
 {
-    int ComputerLoad : 0x3D6E634; // 0 while loading
-    int Pause : 0x3637B00; // 1 paused, 0 unpaused
-    int Loading : 0x236D5B8; // 2369317 0 loading, 2816 while not
     int Chapter : 0x3615208, 0x5C;
     float x : 0x38CD190;
     float y : 0x38CD194;
@@ -25,8 +19,9 @@ startup
     settings.Add("chap", true, "All Chapters");
     settings.Add("end", true, "End Split");
     settings.SetToolTip("end", "The end split for when you finish chapter 17. The opposite of start!");
+
     vars.Chapters = new Dictionary<string,string> 
-	    {
+        {
             {"starter","Chapter 1 - Into the Flame"},
             {"2","Chapter 2 - Something Not Quite Right"},
             {"3","Chapter 3 - Resonances"},
@@ -45,79 +40,65 @@ startup
             {"16","Chapter 16 - In Limbo"},
             {"17","Chapter 17 - A Way Out"},
         };
-    foreach (var Tag in vars.Chapters)
-		{
-			settings.Add(Tag.Key, true, Tag.Value, "chap");
-    	}; 
 
-        vars.onStart = (EventHandler)((s, e) => // thanks gelly for this, it's basically making sure it always clears the vars no matter how livesplit starts
-        {
-            vars.doneMaps.Clear();
-            vars.doneMaps.Add(current.Chapter.ToString());
-        });
+    foreach (var Tag in vars.Chapters)
+    {
+        settings.Add(Tag.Key, true, Tag.Value, "chap");
+    }; 
 
     settings.SetToolTip("starter", "This is used as the starter setting, disabling this also disables the original start command!");
 
-    timer.OnStart += vars.onStart; 
-
-	if (timer.CurrentTimingMethod == TimingMethod.RealTime) // stolen from dude simulator 3, basically asks the runner to set their livesplit to game time
-        {        
+    if (timer.CurrentTimingMethod == TimingMethod.RealTime) // stolen from dude simulator 3, basically asks the runner to set their livesplit to game time
+    {        
         var timingMessage = MessageBox.Show (
-               "This game uses Time without Loads (Game Time) as the main timing method.\n"+
-                "LiveSplit is currently set to show Real Time (RTA).\n"+
-                "Would you like to set the timing method to Game Time? This will make verification easier",
-                "LiveSplit | The Evil Within 2",
-               MessageBoxButtons.YesNo,MessageBoxIcon.Question
-            );
-        
-            if (timingMessage == DialogResult.Yes)
-            {
-                timer.CurrentTimingMethod = TimingMethod.GameTime;
-            }
-        }	
+            "This game uses Time without Loads (Game Time) as the main timing method.\n"+
+            "LiveSplit is currently set to show Real Time (RTA).\n"+
+            "Would you like to set the timing method to Game Time? This will make verification easier",
+            "LiveSplit | The Evil Within 2",
+            MessageBoxButtons.YesNo,MessageBoxIcon.Question
+        );
+    
+        if (timingMessage == DialogResult.Yes)
+        {
+            timer.CurrentTimingMethod = TimingMethod.GameTime;
+        }
+    }
 }
 
 init 
 {
     switch (modules.First().ModuleMemorySize) 
     {
-        case  74637312 : version = "Current Patch"; 
+        case 74637312:
+            version = "Current Patch"; 
             break;
-        case 73007104 : version = "1.02"; 
+        case 73007104:
+            version = "1.02"; 
             break;
-        default:        version = ""; 
+        default:
+            version = ""; 
             break;
     }
 
     vars.doneMaps = new List<string>();
-    vars.endsplit = 0;
-    vars.Loader = 0;
 }
 
-update
-{
-    if(settings["end"])
-    {
-        if (version == "1.02" && current.x > 42099.80858 && current.x < 42099.80860 && current.y > -28778.58009 && current.y < -28778.58007 && current.Chapter == 17)
-        {
-            vars.endsplit = 1;
-        }
-    }
-//|| (current.ComputerLoad == 0 && current.Loading != 0)
-    if ((current.Loading == 0) || (current.Pause == 1))
-    {
-        vars.Loader = 1;
-    }
-    else
-    {
-        vars.Loader = 0;
-    }
-
-}
+update { }
 
 start
 {
-    return ((current.Chapter == 1) && (settings["starter"]) && (old.Chapter != current.Chapter) && (!vars.doneMaps.Contains(current.Chapter.ToString())));
+    return (
+        current.Chapter == 1 &&
+        settings["starter"] &&
+        old.Chapter != current.Chapter &&
+        !vars.doneMaps.Contains(current.Chapter.ToString())
+    );
+}
+
+onStart
+{
+    vars.doneMaps.Clear();
+    vars.doneMaps.Add(current.Chapter.ToString());
 }
 
 split
@@ -126,11 +107,17 @@ split
     {
         vars.doneMaps.Add(current.Chapter.ToString());
         return true;
-    }  
-    
-    if (vars.endsplit == 1)
-    {
-        vars.endsplit = 0;
+    }
+
+    if (
+        settings["end"] &&
+        version == "1.02" &&
+        current.x > 42099.80858 &&
+        current.x < 42099.8086 &&
+        current.y > -28778.58009 &&
+        current.y < -28778.58007 &&
+        current.Chapter == 17
+    ) {
         return true;
     }
 }
@@ -142,10 +129,5 @@ isLoading
 
 reset
 {
-    return (current.Chapter == 0);
-}
-
-exit 
-{
-    timer.OnStart -= vars.onStart;
+    return current.Chapter == 0;
 }

--- a/TheEvilWithin2.asl
+++ b/TheEvilWithin2.asl
@@ -54,6 +54,7 @@ init
 update
 {
     /**
+     * These strings exist in the binary for a debug print.
      * enum GameState {
      *   STATE_PRESS_START = 0,
      *   STATE_USER_SETUP = 1,
@@ -136,9 +137,9 @@ update
 start
 {
     return (
-        current.chapterId == 1 &&
         settings["starter"] &&
         old.chapterId != current.chapterId &&
+        current.chapterId == 1 &&
         !vars.doneMaps.Contains(current.chapterId.ToString())
     );
 }


### PR DESCRIPTION
This PR primarily fixes the loading issues in the The Evil Within 2 autosplitter. The problem child was the isPaused value, which also flicked to 1 during weapon wheel animations and when taking damage.

It also slightly changes the timing for the monitor warp, using the loading spinner to determine when the game is loading.

Currently, it's missing only the loading screen back to the main menu, but since there's already a reset when you go back to main menu, I didn't consider this to be a large issue.

These fields were found by reverse engineering the game in Ghidra, and stepping through the code.

I've also converted everything to use sigscanning, so that this is version and platform independent.

(I also fixed the formatting)

Please do not merge until
- [x] This has been tested (I will poke people about this)
- [ ] `asl-help` is added to the autosplitter in LiveSplit.Autosplitters (when the PR is reviewed, I will raise a corresponding PR to the repo to add this)